### PR TITLE
Add Bot Moderator Elevated Permission for Certain Commands

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -3,6 +3,7 @@
         "token": "",
         "clientId": "",
         "botOwnerIds": [],
+        "botModeratorIds": [],
         "debugGuildIds": []
     },
     "ucsdInfo": {

--- a/src/commands/BaseCommand.ts
+++ b/src/commands/BaseCommand.ts
@@ -272,8 +272,17 @@ export default abstract class BaseCommand {
 
         // If the command is bot owner only and the person isn't a bot owner, then this person can't run this command.
         if (
-            this.commandInfo.botOwnerOnly &&
-            !DataRegistry.CONFIG.discord.botOwnerIds.includes(userToTest.id)
+            this.commandInfo.botOwnerOnly 
+            && !DataRegistry.CONFIG.discord.botOwnerIds.includes(userToTest.id)
+        ) {
+            return results;
+        }
+
+        // If the command is moderator only and the operson isn't a moderator or owner, then deny permission
+        if (
+            this.commandInfo.botModeratorIds
+            && !DataRegistry.CONFIG.discord.botModeratorIds.includes(userToTest.id)
+            && !DataRegistry.CONFIG.discord.botOwnerIds.includes(userToTest.id)
         ) {
             return results;
         }
@@ -405,6 +414,12 @@ export interface ICommandConf {
      * Whether the command is for the bot owner only.
      */
     botOwnerOnly: boolean;
+
+    /**
+     * Whether the command is for the bot owner or bot moderator
+     * users only.
+     */
+    botModeratorIds: boolean;
 }
 
 export interface IArgumentInfo {

--- a/src/commands/BaseCommand.ts
+++ b/src/commands/BaseCommand.ts
@@ -138,6 +138,12 @@ function addArgument(scb: SlashCommandBuilder, argInfo: IArgumentInfo): void {
     }
 }
 
+export enum RequiredElevatedPermission {
+    None,
+    ModOrOwner,
+    OwnerOnly
+}
+
 export default abstract class BaseCommand {
     /**
      * The command info object.
@@ -270,18 +276,16 @@ export default abstract class BaseCommand {
             reason: "",
         };
 
-        // If the command is bot owner only and the person isn't a bot owner, then this person can't run this command.
         if (
-            this.commandInfo.botOwnerOnly 
+            this.commandInfo.elevatedPermReq === RequiredElevatedPermission.ModOrOwner 
+            && !DataRegistry.CONFIG.discord.botModeratorIds.includes(userToTest.id)
             && !DataRegistry.CONFIG.discord.botOwnerIds.includes(userToTest.id)
         ) {
             return results;
         }
 
-        // If the command is moderator only and the operson isn't a moderator or owner, then deny permission
         if (
-            this.commandInfo.botModeratorIds
-            && !DataRegistry.CONFIG.discord.botModeratorIds.includes(userToTest.id)
+            this.commandInfo.elevatedPermReq === RequiredElevatedPermission.OwnerOnly
             && !DataRegistry.CONFIG.discord.botOwnerIds.includes(userToTest.id)
         ) {
             return results;
@@ -411,15 +415,10 @@ export interface ICommandConf {
     guildOnly: boolean;
 
     /**
-     * Whether the command is for the bot owner only.
+     * Determines whether a user requires a certain elevated bot permission to run
+     * this command.
      */
-    botOwnerOnly: boolean;
-
-    /**
-     * Whether the command is for the bot owner or bot moderator
-     * users only.
-     */
-    botModeratorIds: boolean;
+    elevatedPermReq: RequiredElevatedPermission;
 }
 
 export interface IArgumentInfo {

--- a/src/commands/enroll-data/GetCape.ts
+++ b/src/commands/enroll-data/GetCape.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ArgumentType, ICommandContext } from "../BaseCommand";
+import BaseCommand, { ArgumentType, ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { EmojiConstants } from "../../Constants";
 import { ButtonBuilder, ButtonStyle, StringSelectMenuBuilder } from "discord.js";
 import { AdvancedCollector, ArrayUtilities } from "../../utilities";
@@ -43,8 +43,7 @@ export default class GetCape extends BaseCommand {
                 },
             ],
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/enroll-data/GetCape.ts
+++ b/src/commands/enroll-data/GetCape.ts
@@ -44,6 +44,7 @@ export default class GetCape extends BaseCommand {
             ],
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/enroll-data/GetOverallEnroll.ts
+++ b/src/commands/enroll-data/GetOverallEnroll.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ICommandContext } from "../BaseCommand";
+import BaseCommand, { ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { DataRegistry } from "../../DataRegistry";
 import { parseCourseSubjCode, PLOT_ARGUMENTS } from "./helpers/Helper";
 import { Collection } from "discord.js";
@@ -16,8 +16,7 @@ export default class GetOverallEnroll extends BaseCommand {
             commandCooldown: 5 * 1000,
             argumentInfo: PLOT_ARGUMENTS,
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/enroll-data/GetOverallEnroll.ts
+++ b/src/commands/enroll-data/GetOverallEnroll.ts
@@ -17,6 +17,7 @@ export default class GetOverallEnroll extends BaseCommand {
             argumentInfo: PLOT_ARGUMENTS,
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/enroll-data/GetPrereq.ts
+++ b/src/commands/enroll-data/GetPrereq.ts
@@ -19,6 +19,7 @@ export default class GetPrereq extends BaseCommand {
             argumentInfo: LOOKUP_ARGUMENTS,
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/enroll-data/GetPrereq.ts
+++ b/src/commands/enroll-data/GetPrereq.ts
@@ -1,5 +1,5 @@
 import { EmbedBuilder } from "discord.js";
-import BaseCommand, { ICommandContext } from "../BaseCommand";
+import BaseCommand, { ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { LOOKUP_ARGUMENTS, parseCourseSubjCode } from "./helpers/Helper";
 import { PrerequisiteInfo } from "../../definitions";
 import { ArrayUtilities, ScraperApiWrapper, ScraperResponse, StringUtil } from "../../utilities";
@@ -18,8 +18,7 @@ export default class GetPrereq extends BaseCommand {
             commandCooldown: 5 * 1000,
             argumentInfo: LOOKUP_ARGUMENTS,
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/enroll-data/LiveSeatLegends.ts
+++ b/src/commands/enroll-data/LiveSeatLegends.ts
@@ -1,5 +1,5 @@
 import { GeneralUtilities } from "../../utilities";
-import BaseCommand, { ICommandContext } from "../BaseCommand";
+import BaseCommand, { ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 
 export default class LiveSeatLegends extends BaseCommand {
     public constructor() {
@@ -13,8 +13,7 @@ export default class LiveSeatLegends extends BaseCommand {
             commandCooldown: 5 * 1000,
             argumentInfo: [],
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/enroll-data/LiveSeatLegends.ts
+++ b/src/commands/enroll-data/LiveSeatLegends.ts
@@ -14,6 +14,7 @@ export default class LiveSeatLegends extends BaseCommand {
             argumentInfo: [],
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/enroll-data/LiveSeats.ts
+++ b/src/commands/enroll-data/LiveSeats.ts
@@ -22,6 +22,7 @@ export default class LiveSeats extends BaseCommand {
             argumentInfo: LOOKUP_ARGUMENTS,
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/enroll-data/LiveSeats.ts
+++ b/src/commands/enroll-data/LiveSeats.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ICommandContext } from "../BaseCommand";
+import BaseCommand, { ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { getColorByPercent, LOOKUP_ARGUMENTS, parseCourseSubjCode, requestFromWebRegApi, } from "./helpers/Helper";
 import { EmojiConstants, GeneralConstants } from "../../Constants";
 import { ArrayUtilities, ScraperApiWrapper, ScraperResponse, StringBuilder, StringUtil } from "../../utilities";
@@ -21,8 +21,7 @@ export default class LiveSeats extends BaseCommand {
             commandCooldown: 5 * 1000,
             argumentInfo: LOOKUP_ARGUMENTS,
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/enroll-data/LookupCached.ts
+++ b/src/commands/enroll-data/LookupCached.ts
@@ -26,6 +26,7 @@ export default class LookupCached extends BaseCommand {
             ],
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/enroll-data/LookupCached.ts
+++ b/src/commands/enroll-data/LookupCached.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ArgumentType, ICommandContext } from "../BaseCommand";
+import BaseCommand, { ArgumentType, ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { displayInteractiveWebregData, parseCourseSubjCode } from "./helpers/Helper";
 import { DataRegistry } from "../../DataRegistry";
 
@@ -25,8 +25,7 @@ export default class LookupCached extends BaseCommand {
                 },
             ],
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/enroll-data/LookupLive.ts
+++ b/src/commands/enroll-data/LookupLive.ts
@@ -24,6 +24,7 @@ export default class LookupLive extends BaseCommand {
             argumentInfo: LOOKUP_ARGUMENTS,
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/enroll-data/LookupLive.ts
+++ b/src/commands/enroll-data/LookupLive.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ICommandContext } from "../BaseCommand";
+import BaseCommand, { ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import {
     displayInteractiveWebregData,
     LOOKUP_ARGUMENTS,
@@ -23,8 +23,7 @@ export default class LookupLive extends BaseCommand {
             commandCooldown: 5 * 1000,
             argumentInfo: LOOKUP_ARGUMENTS,
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/enroll-data/SearchCourse.ts
+++ b/src/commands/enroll-data/SearchCourse.ts
@@ -125,6 +125,7 @@ export default class SearchCourse extends BaseCommand {
             ]),
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/enroll-data/SearchCourse.ts
+++ b/src/commands/enroll-data/SearchCourse.ts
@@ -10,7 +10,7 @@ import {
     StringUtil,
     TimeUtilities
 } from "../../utilities";
-import BaseCommand, { ArgumentType, ICommandContext } from "../BaseCommand";
+import BaseCommand, { ArgumentType, ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { TERM_ARGUMENTS } from "./helpers/Helper";
 import * as table from "text-table";
 
@@ -124,8 +124,7 @@ export default class SearchCourse extends BaseCommand {
                 },
             ]),
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/general/Help.ts
+++ b/src/commands/general/Help.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ArgumentType, IArgumentInfo, ICommandConf, ICommandContext, } from "../BaseCommand";
+import BaseCommand, { ArgumentType, IArgumentInfo, ICommandConf, ICommandContext, RequiredElevatedPermission, } from "../BaseCommand";
 
 import { ArrayUtilities, GeneralUtilities, StringBuilder, StringUtil } from "../../utilities";
 import { CommandRegistry } from "..";
@@ -24,8 +24,7 @@ export default class Help extends BaseCommand {
             ],
             commandCooldown: 4 * 1000,
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         };
 
         super(cmi);
@@ -41,6 +40,20 @@ export default class Help extends BaseCommand {
         if (cmdName) {
             const command = CommandRegistry.getCommandByName(cmdName);
             if (command) {
+                let elevatedPerm: string;
+                if (command.commandInfo.elevatedPermReq === RequiredElevatedPermission.None) {
+                    elevatedPerm = "None";
+                }
+                else if (command.commandInfo.elevatedPermReq === RequiredElevatedPermission.ModOrOwner) {
+                    elevatedPerm = "Bot Moderator or Bot Owner";
+                }
+                else if (command.commandInfo.elevatedPermReq === RequiredElevatedPermission.OwnerOnly) {
+                    elevatedPerm = "Bot Owner Only";
+                }
+                else {
+                    elevatedPerm = "Unknown";
+                }
+
                 const cmdHelpEmbed = GeneralUtilities.generateBlankEmbed(ctx.user, "Green")
                     .setTitle(`Command Help: **${command.commandInfo.formalCommandName}**`)
                     .setFooter({
@@ -57,8 +70,8 @@ export default class Help extends BaseCommand {
                         inline: true
                     })
                     .addFields({
-                        name: "Bot Owner Only?",
-                        value: StringUtil.codifyString(command.commandInfo.botOwnerOnly ? "Yes" : "No"),
+                        name: "Elevated Permission Required?",
+                        value: StringUtil.codifyString(elevatedPerm),
                         inline: true
                     })
                     .addFields({

--- a/src/commands/general/Help.ts
+++ b/src/commands/general/Help.ts
@@ -25,6 +25,7 @@ export default class Help extends BaseCommand {
             commandCooldown: 4 * 1000,
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         };
 
         super(cmi);

--- a/src/commands/general/Ping.ts
+++ b/src/commands/general/Ping.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ICommandContext } from "../BaseCommand";
+import BaseCommand, { ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 
 export default class Ping extends BaseCommand {
     public constructor() {
@@ -12,8 +12,7 @@ export default class Ping extends BaseCommand {
             commandCooldown: 3 * 1000,
             argumentInfo: [],
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/general/Ping.ts
+++ b/src/commands/general/Ping.ts
@@ -13,6 +13,7 @@ export default class Ping extends BaseCommand {
             argumentInfo: [],
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/general/Status.ts
+++ b/src/commands/general/Status.ts
@@ -18,6 +18,7 @@ export default class Status extends BaseCommand {
             argumentInfo: [],
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/general/Status.ts
+++ b/src/commands/general/Status.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ICommandContext } from "../BaseCommand";
+import BaseCommand, { ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { EmbedBuilder } from "discord.js";
 import { StringUtil, TimeUtilities } from "../../utilities";
 import { Bot } from "../../Bot";
@@ -17,8 +17,7 @@ export default class Status extends BaseCommand {
             commandCooldown: 3 * 1000,
             argumentInfo: [],
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/owner/Exec.ts
+++ b/src/commands/owner/Exec.ts
@@ -27,6 +27,7 @@ export default class Exec extends BaseCommand {
             ],
             guildOnly: false,
             botOwnerOnly: true,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/owner/Exec.ts
+++ b/src/commands/owner/Exec.ts
@@ -3,7 +3,7 @@ import { AttachmentBuilder, EmbedBuilder } from "discord.js";
 import { promisify } from "util";
 import { EmojiConstants, GeneralConstants } from "../../Constants";
 import { StringUtil } from "../../utilities";
-import BaseCommand, { ArgumentType, ICommandContext } from "../BaseCommand";
+import BaseCommand, { ArgumentType, ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 
 export default class Exec extends BaseCommand {
     public constructor() {
@@ -26,8 +26,7 @@ export default class Exec extends BaseCommand {
                 },
             ],
             guildOnly: false,
-            botOwnerOnly: true,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.OwnerOnly
         });
     }
 

--- a/src/commands/owner/ScraperStats.ts
+++ b/src/commands/owner/ScraperStats.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ICommandContext } from "../BaseCommand";
+import BaseCommand, { ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { ScraperApiWrapper, StringUtil, TimestampType, TimeUtilities } from "../../utilities";
 import { DataRegistry } from "../../DataRegistry";
 import { EmbedBuilder } from "discord.js";
@@ -17,8 +17,7 @@ export default class LoginScriptStats extends BaseCommand {
             commandCooldown: 3 * 1000,
             argumentInfo: [],
             guildOnly: false,
-            botOwnerOnly: true,
-            botModeratorIds: true
+            elevatedPermReq: RequiredElevatedPermission.ModOrOwner
         });
     }
 

--- a/src/commands/owner/ScraperStats.ts
+++ b/src/commands/owner/ScraperStats.ts
@@ -18,6 +18,7 @@ export default class LoginScriptStats extends BaseCommand {
             argumentInfo: [],
             guildOnly: false,
             botOwnerOnly: true,
+            botModeratorIds: true
         });
     }
 

--- a/src/commands/owner/SetActivity.ts
+++ b/src/commands/owner/SetActivity.ts
@@ -37,7 +37,8 @@ export default class SetActivity extends BaseCommand {
             ],
             botPermissions: [],
             guildOnly: false,
-            botOwnerOnly: true
+            botOwnerOnly: true,
+            botModeratorIds: true
         };
 
         super(cmi);

--- a/src/commands/owner/SetActivity.ts
+++ b/src/commands/owner/SetActivity.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ArgumentType, ICommandConf, ICommandContext } from "../BaseCommand";
+import BaseCommand, { ArgumentType, ICommandConf, ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { ActivitiesOptions, ActivityType, PresenceData } from "discord.js";
 
 export default class SetActivity extends BaseCommand {
@@ -37,8 +37,7 @@ export default class SetActivity extends BaseCommand {
             ],
             botPermissions: [],
             guildOnly: false,
-            botOwnerOnly: true,
-            botModeratorIds: true
+            elevatedPermReq: RequiredElevatedPermission.ModOrOwner
         };
 
         super(cmi);

--- a/src/commands/owner/_.ts
+++ b/src/commands/owner/_.ts
@@ -1,5 +1,5 @@
 import { ICategoryConf } from "../../definitions";
 
 export default {
-    categoryName: "Bot Owner Only"
+    categoryName: "Bot Owner & Moderators Only"
 } as ICategoryConf;

--- a/src/commands/ucsd/AllClassrooms.ts
+++ b/src/commands/ucsd/AllClassrooms.ts
@@ -41,6 +41,7 @@ export default class ViewAllClassrooms extends BaseCommand {
             ],
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/ucsd/AllClassrooms.ts
+++ b/src/commands/ucsd/AllClassrooms.ts
@@ -1,5 +1,5 @@
 // "If it works, don't question it."
-import BaseCommand, { ArgumentType, ICommandContext } from "../BaseCommand";
+import BaseCommand, { ArgumentType, ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { DataRegistry } from "../../DataRegistry";
 import { AdvancedCollector, ArrayUtilities, StringBuilder, StringUtil, TimeUtilities } from "../../utilities";
 import {
@@ -40,8 +40,7 @@ export default class ViewAllClassrooms extends BaseCommand {
                 }
             ],
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/ucsd/CheckRoom.ts
+++ b/src/commands/ucsd/CheckRoom.ts
@@ -46,6 +46,7 @@ export default class CheckRoom extends BaseCommand {
             ],
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/ucsd/CheckRoom.ts
+++ b/src/commands/ucsd/CheckRoom.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ArgumentType, ICommandContext } from "../BaseCommand";
+import BaseCommand, { ArgumentType, ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import {
     ButtonBuilder,
     ButtonStyle,
@@ -45,8 +45,7 @@ export default class CheckRoom extends BaseCommand {
                 },
             ],
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/ucsd/CourseInfo.ts
+++ b/src/commands/ucsd/CourseInfo.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ArgumentType, ICommandContext } from "../BaseCommand";
+import BaseCommand, { ArgumentType, ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { EmbedBuilder } from "discord.js";
 import { ArrayUtilities, StringUtil } from "../../utilities";
 import { parseCourseSubjCode } from "../enroll-data/helpers/Helper";
@@ -28,8 +28,7 @@ export default class CourseInfo extends BaseCommand {
                 },
             ],
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/commands/ucsd/CourseInfo.ts
+++ b/src/commands/ucsd/CourseInfo.ts
@@ -29,6 +29,7 @@ export default class CourseInfo extends BaseCommand {
             ],
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/ucsd/Waitz.ts
+++ b/src/commands/ucsd/Waitz.ts
@@ -27,6 +27,7 @@ export default class Waitz extends BaseCommand {
             argumentInfo: [],
             guildOnly: false,
             botOwnerOnly: false,
+            botModeratorIds: false
         });
     }
 

--- a/src/commands/ucsd/Waitz.ts
+++ b/src/commands/ucsd/Waitz.ts
@@ -1,4 +1,4 @@
-import BaseCommand, { ICommandContext } from "../BaseCommand";
+import BaseCommand, { ICommandContext, RequiredElevatedPermission } from "../BaseCommand";
 import { AdvancedCollector, ArrayUtilities, GeneralUtilities, StringBuilder, StringUtil } from "../../utilities";
 import { WaitzCompareData, WaitzLiveData } from "../../definitions";
 import {
@@ -26,8 +26,7 @@ export default class Waitz extends BaseCommand {
             commandCooldown: 5 * 1000,
             argumentInfo: [],
             guildOnly: false,
-            botOwnerOnly: false,
-            botModeratorIds: false
+            elevatedPermReq: RequiredElevatedPermission.None
         });
     }
 

--- a/src/definitions/ConfigTypes.ts
+++ b/src/definitions/ConfigTypes.ts
@@ -6,6 +6,7 @@ export interface IConfiguration {
         token: string;
         clientId: string;
         botOwnerIds: string[];
+        botModeratorIds: string[];
         debugGuildIds: string[];
     };
     ucsdInfo: IApiInfo & {


### PR DESCRIPTION
Adds another elevated permission called bot moderators. Like bot owners, bot moderators can access commands that most users cannot use. However, bot moderators cannot access certain commands that bot owners can, like `exec`.